### PR TITLE
[Fix]-Splash컴포넌트 내부의 주석처리 되어 있는 useEffect 부분의 주석을 해제, 버그 픽스.

### DIFF
--- a/src/Components/Splash/Splash.jsx
+++ b/src/Components/Splash/Splash.jsx
@@ -5,13 +5,13 @@ import mainChar from "../../assets/image/main_char.png";
 import styles from "./splash.module.css";
 
 export default function Splash() {
-  //   const navigate = useNavigate();
+    const navigate = useNavigate();
 
-  //   useEffect(() => {
-  //     setTimeout(() => {
-  //       navigate("/login");
-  //     }, 2000);
-  //   }, []);
+    useEffect(() => {
+      setTimeout(() => {
+        navigate("/main");
+      }, 2000);
+    }, []);
 
   return (
     <div className={styles["splash-container"]}>


### PR DESCRIPTION
# PR 제목

사이트 접속시 스플래시 화면에서 메인페이지로 넘어가지 않는 문제 수정.

# 변경 사항

- [x] Splash컴포넌트 내의 메인화면으로 넘어가는 로직을 가진 useEffect가 주석처리 되어 있어 발생한 버그. 주석 해제 후 문제 해결.
- [x] 연결되는 페이지를 로그인에서 메인페이지로 변경.

# 관련 이슈

- #46 
- #39 
