### PR TITLE
Feature #103 마이프로필 기능구현

### DIFF
--- a/src/API/myInfoAPI.js
+++ b/src/API/myInfoAPI.js
@@ -12,7 +12,7 @@ async function myInfoAPI() {
             },
         })
         const myInfo = result.data
-        return await myInfo
+        return myInfo
     } catch (error) {
         console.log("myinfo api 에러: ", error)
     }

--- a/src/API/userInfoAPI.js
+++ b/src/API/userInfoAPI.js
@@ -1,0 +1,20 @@
+// myInfo와 다르게 url의 accountName에 해당하는 유저의 정보를 가져옵니다.(가져오는 정보는 myInfo와 동일하기 때문에 현재 로그인한 유저, 즉 내 accountName을 넣으면 myInfo와 완전히 동일하게 작동합니다.)
+import axios from "axios";
+
+async function userInfoAPI(accountName) {
+  const token = localStorage.getItem("token");
+  try {
+    let result = await axios.get(`https://api.mandarin.weniv.co.kr/profile/${accountName}`,
+    {
+      headers: {
+        "Authorization": `Bearer ${token}`
+      }
+    })
+    const userInfo = result.data;
+    return userInfo
+  } catch(error) {
+    console.log("유저 데이터를 가져오지 못했습니다: ", error)
+  }
+}
+
+export default userInfoAPI

--- a/src/API/userPostListAPI.js
+++ b/src/API/userPostListAPI.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+async function userPostListAPI(accountName) {
+  const token = localStorage.getItem("token");
+  try {
+    let result = await axios.get(`https://api.mandarin.weniv.co.kr/post/${accountName}/userpost`,
+    {
+      headers: {
+        "Authorization": `Bearer ${token}`
+      }
+    })
+    const userInfo = result.data.post;
+    return userInfo
+  } catch(error) {
+    console.log("유저의 게시글 데이터를 가져오지 못했습니다: ", error)
+    return 0
+  }
+}
+
+export default userPostListAPI

--- a/src/Components/Commons/Footer.jsx
+++ b/src/Components/Commons/Footer.jsx
@@ -1,20 +1,34 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 import { ReactComponent as HomeIcon } from "../../assets/image/HomeIcon.svg";
 import { ReactComponent as ChatIcon } from "../../assets/image/ChatIcon.svg";
 import { ReactComponent as WriteIcon } from "../../assets/image/WriteIcon.svg";
 import { ReactComponent as ProfileIcon } from "../../assets/image/ProfileIcon.svg";
+import myInfoAPI from '../../API/myInfoAPI';
+import { useRecoilState  } from "recoil";
+import { userAccountNameAtom } from "../../Store/Store";
 
 function Footer() {
+  const [userData, setUserData] = useRecoilState(userAccountNameAtom);
   const [$active, setActive] = useState("home");
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const myInfo = await myInfoAPI();
+      setUserData({
+        accountname: myInfo.user.accountname,
+      });
+    }
+    fetchData();
+  }, []);
 
   const menus = [
     { name: "홈", icon: StyledHomeIcon, path: "/main", id: "home" },
     { name: "채팅", icon: StyledChatIcon, path: "/chat", id: "chat" },
     { name: "게시물 작성", icon: StyledWriteIcon, path: "/write", id: "write" },
-    { name: "프로필", icon: StyledProfileIcon, path: "/profile", id: "profile" }
+    { name: "프로필", icon: StyledProfileIcon, path: `/profile/${userData.accountname}`, id: "profile" }
   ];
 
   return (

--- a/src/Components/Profile/FollowList/FollowList.jsx
+++ b/src/Components/Profile/FollowList/FollowList.jsx
@@ -1,9 +1,10 @@
 import React, {useState, useEffect} from 'react'
+import { useParams } from 'react-router';
 import * as S from "./FollowListStyle";
 import { useRecoilState  } from "recoil";
 import { userDataAtom } from "../../../Store/Store";
 import followerAPI from "../../../API/followAPI/followerAPI"
-import myInfoAPI from '../../../API/myInfoAPI';
+import userInfoAPI from '../../../API/userInfoAPI';
 import followAPI from "../../../API/followAPI/followAPI"
 import unFollowAPI from "../../../API/followAPI/unFollowAPI"
 
@@ -11,20 +12,21 @@ function FollowList() {
   const [userData, setUserData] = useRecoilState(userDataAtom);
   const [followData, setFollowData] = useState([])
   const [render, ReRender] = useState(true)
+  const {accountname, type} = useParams();
   const isFollowerList = "follower"; // 팔로잉 목록을 불러올지, 팔로우 목록을 불러올지 정하는 변수. "follower"면 팔로워 목록이, "following"이면 팔로잉 목록을 불러온다.
 
   // 페이지가 렌더링 되면, recoil 아톰에 현재 로그인한 내 정보를 저장하고 followerAPI를 사용해 데이터를 불러온다
   useEffect(() => {
     const fetchData = async () => {
-      const myInfo = await myInfoAPI();
+      const userInfo = await userInfoAPI(accountname);
       setUserData({
-        _id: myInfo.user._id,
-        username: myInfo.user.username,
-        accountname: myInfo.user.accountname,
-        following: myInfo.user.following,
+        _id: userInfo.profile._id,
+        username: userInfo.profile.username,
+        accountname: userInfo.profile.accountname,
+        following: userInfo.profile.following,
       });
       
-      const result = await followerAPI("gb_account_forTest", isFollowerList);
+      const result = await followerAPI(accountname, type);
       setFollowData(result);
     }
     fetchData();

--- a/src/Components/Profile/ProfileDetail/ProfileDetail.jsx
+++ b/src/Components/Profile/ProfileDetail/ProfileDetail.jsx
@@ -1,8 +1,13 @@
 import React, { useState } from "react";
 import * as S from "./ProfileDetailStyle";
 import { useNavigate } from "react-router-dom";
+import { useRecoilState  } from "recoil";
+import { userDataAtom } from "../../../Store/Store";
+import { userPostListAtom } from "../../../Store/Store";
 
 function Profile({ isMyProfile }) {
+  const [userData, setUserData] = useRecoilState(userDataAtom);
+  const [userPostList] = useRecoilState(userPostListAtom);
   const navigate = useNavigate();
 
   //팔로잉 여부
@@ -12,29 +17,29 @@ function Profile({ isMyProfile }) {
     <S.ProfileContainer>
       <S.ProfileHeader>
         {/* AccountName 넣을 자리 */}
-        <S.AccountName>@game_buddy12</S.AccountName>
+        <S.AccountName>{userData.accountname}</S.AccountName>
         <S.ProfileSection>
           {/* 프로필 사진 */}
-          <S.ProfileImage alt="프로필 이미지" />
+          <S.ProfileImage src={userData.image} alt="" />
           <S.ProfileStat>
             <S.StatContent>
-              <S.StatButton onClick={() => navigate("/followers")}>
+              <S.StatButton onClick={() => navigate("/follow")}>
                 {/* 팔로워 수 */}
-                <strong>2950</strong>
+                <strong>{userData.followerCount}</strong>
                 <div>followers</div>
               </S.StatButton>
             </S.StatContent>
             <S.StatContent>
               <S.Stat>
                 {/* 게시글 수 */}
-                <strong>128</strong>
+                <strong>{userPostList.postList.length}</strong>
                 <div>Post</div>
               </S.Stat>
             </S.StatContent>
             <S.StatContent>
-              <S.StatButton onClick={() => navigate("/followers")}>
+              <S.StatButton onClick={() => navigate("/follow")}>
                 {/* 팔로잉 수 */}
-                <strong>290</strong>
+                <strong>{userData.followingCount}</strong>
                 <div>followings</div>
               </S.StatButton>
             </S.StatContent>
@@ -43,9 +48,9 @@ function Profile({ isMyProfile }) {
       </S.ProfileHeader>
       <S.ProfileDescription>
         {/* userName */}
-        <S.UserName>벌크업뱅</S.UserName>
+        <S.UserName>{userData.username}</S.UserName>
         {/* 소개글 */}
-        <S.DescriptionText>안녕하세요 반갑섭니다리</S.DescriptionText>
+        <S.DescriptionText>{userData.intro}</S.DescriptionText>
       </S.ProfileDescription>
       <S.ButtonContainer>
         {/* 나의 프로필인지 아닌지에 따라 이동경로와 내용 달라짐 */}

--- a/src/Components/Profile/ProfileDetail/ProfileDetail.jsx
+++ b/src/Components/Profile/ProfileDetail/ProfileDetail.jsx
@@ -5,7 +5,7 @@ import { useRecoilState  } from "recoil";
 import { userDataAtom } from "../../../Store/Store";
 import { userPostListAtom } from "../../../Store/Store";
 
-function Profile({ isMyProfile }) {
+function Profile({ isMyProfile, accountname }) {
   const [userData, setUserData] = useRecoilState(userDataAtom);
   const [userPostList] = useRecoilState(userPostListAtom);
   const navigate = useNavigate();
@@ -23,7 +23,7 @@ function Profile({ isMyProfile }) {
           <S.ProfileImage src={userData.image} alt="" />
           <S.ProfileStat>
             <S.StatContent>
-              <S.StatButton onClick={() => navigate("/follow")}>
+              <S.StatButton onClick={() => navigate(`/follow/${accountname}/follower`)}>
                 {/* 팔로워 수 */}
                 <strong>{userData.followerCount}</strong>
                 <div>followers</div>
@@ -37,7 +37,7 @@ function Profile({ isMyProfile }) {
               </S.Stat>
             </S.StatContent>
             <S.StatContent>
-              <S.StatButton onClick={() => navigate("/follow")}>
+              <S.StatButton onClick={() => navigate(`/follow/${accountname}/following`)}>
                 {/* 팔로잉 수 */}
                 <strong>{userData.followingCount}</strong>
                 <div>followings</div>

--- a/src/Components/Profile/ProfileDetail/ProfileDetailStyle.jsx
+++ b/src/Components/Profile/ProfileDetail/ProfileDetailStyle.jsx
@@ -32,11 +32,11 @@ export const ProfileSection = styled.div`
   width: 100%;
 `;
 
-export const ProfileImage = styled.div`
-  width: 110px;
+export const ProfileImage = styled.img`
+  width: 100px;
   height: 100px;
   border-radius: 50%;
-  background-color: #ece8e8;
+  /* background-color: #ece8e8; */
   margin-right: 30px;
 `;
 

--- a/src/Pages/ChattingListPage.jsx
+++ b/src/Pages/ChattingListPage.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Header from "../Components/Commons/Header/Header";
+import Footer from "../Components/Commons/Footer";
 import ChattingList from "../Components/Chat/ChattingList";
 
 function ChattingListPage() {
@@ -7,6 +8,7 @@ function ChattingListPage() {
     <>
       <Header type={"chat"} />
       <ChattingList />
+      <Footer />
     </>
   );
 }

--- a/src/Pages/ProfilePage.jsx
+++ b/src/Pages/ProfilePage.jsx
@@ -1,16 +1,47 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Header from "../Components/Commons/Header/Header";
 import ProfileDetail from "../Components/Profile/ProfileDetail/ProfileDetail";
 import Recruit from "../Components/Profile/Recruit/Recruit";
 import MyPostList from "../Components/Profile/MyPostList/MyPostList";
 import Footer from "../Components/Commons/Footer";
 import { useParams } from "react-router-dom";
+import { useRecoilState  } from "recoil";
+import { userDataAtom } from "../Store/Store";
+import { userAccountNameAtom } from "../Store/Store"
+import { userPostListAtom } from "../Store/Store"
+import userInfoAPI from "../API/userInfoAPI";
+import userPostListAPI from "../API/userPostListAPI";
+
 
 function ProfilePage() {
-  // UserProfile의 경로 profile/:id 에서 :id를 가져온 뒤 id 변수에 할당
+  const [userData, setUserData] = useRecoilState(userDataAtom);
+  const [userPostList, setUserPostList] = useRecoilState(userPostListAtom);
+  const [nowAccountName] = useRecoilState(userAccountNameAtom);
   const { accountname } = useParams();
-  // id값이 존재하지 않으면 myProfile이 됨
-  const isMyProfile = !accountname;
+
+  // UserProfile의 경로 profile/:id 에서 :id를 가져온 뒤 id 변수에 할당
+  useEffect(() => {
+    const fetchData = async () => {
+      const userInfo = await userInfoAPI(accountname);
+      setUserData({
+        username: userInfo.profile.username,
+        accountname: userInfo.profile.accountname,
+        image: userInfo.profile.image,
+        intro: userInfo.profile.intro,
+        followerCount: userInfo.profile.followerCount,
+        followingCount: userInfo.profile.followingCount
+      });
+      const userPostList = await userPostListAPI(accountname);
+      console.log(userPostList)
+      setUserPostList({
+        postList: userPostList
+      })
+    }
+    fetchData();
+  }, []);
+
+    // true면 마이 프로필
+    let isMyProfile = accountname === nowAccountName.accountname
 
   // 팔로우 상태
   const [isFollowing, setIsFollowing] = useState(true);

--- a/src/Pages/ProfilePage.jsx
+++ b/src/Pages/ProfilePage.jsx
@@ -53,6 +53,7 @@ function ProfilePage() {
         isMyProfile={isMyProfile}
         isFollowing={isFollowing}
         setIsFollowing={setIsFollowing}
+        accountname={accountname}
       />
       {/* 팔로우가 되어있을 때만 Recruit, MyPostList 컴포넌트가 렌더링 됨 */}
       {/* 현재 팔로우 기능이 구현되지 않았기 때문에, 초기값은 true(팔로잉)이므로 두 컴포넌트 다 렌더링됩니다. */}

--- a/src/Router/Router.jsx
+++ b/src/Router/Router.jsx
@@ -29,7 +29,7 @@ function Router() {
         <Route path="/chat" element={<ChattingListPage />} />
         <Route path="/write" element={<WritePage />} />
         <Route path="/profile" element={<ProfilePage />} />
-        <Route path="/follow" element={<FollowDetailPage />} />
+        <Route path="/follow/:accountname/:type" element={<FollowDetailPage />} />
         <Route path="/profile/:accountname" element={<ProfilePage />} />
         <Route path="/fix" element={<Profile />} />
         <Route path="/chat" element={<ChattingListPage />} />

--- a/src/Store/Store.js
+++ b/src/Store/Store.js
@@ -9,9 +9,28 @@ export const userDataAtom = atom({
         "email": "",
         "accountname": "",
         "image": "",
+        "intro": "",
         "token": "",
         "following": [],
-        "follower": []
+        "follower": [],
+        "followerCount": 0,
+        "followingCount": 0
+    }
+})
+
+//푸터에서 사용하며, 푸터가 있는 모든 페이지에서 사용가능한 userAccount 저장용 atom
+export const userAccountNameAtom = atom({
+    key: "userAccountNameAtom",
+    default: {
+        "accountname": ""
+    }
+})
+
+// 원하는 유저의 게시글 목록을 저장하는 atom
+export const userPostListAtom = atom({
+    key: "userPostListAtom",
+    default: {
+        "postList": []
     }
 })
 


### PR DESCRIPTION
# PR 제목

프로필페이지 기능구현

# 변경 사항

- [x] 푸터에서 현재 로그인한 유저의 어카운트네임을 아톰에 저장함. 이제 푸터가 있는 모든 페이지에서 저장한 어카운트 네임 사용 가능
- [x] 프로필 페이지 완성. url에 어카운트 네임을 입력하면 해당 유저의 프로필로 이동하며, 현재 로그인한 유저라면 마이프로필페이지, 아니라면 해당유저프로필 페이지가 적용되어 나타남.
- [x] 팔로우 팔로잉 페이지 완성 및 프로필 페이지와 연동 완료
- [x] 이제 프로필 페이지에서 해당 프로필유저의 게시글 목록도 아톰에 저장. (이건 나중에 프로필페이지의 유저게시글 기능 구현할 때도 쓰면 좋을듯)

# 관련 이슈

